### PR TITLE
style(account): 优化元素间隔

### DIFF
--- a/src/views/account/components/AccountManagement.vue
+++ b/src/views/account/components/AccountManagement.vue
@@ -47,12 +47,9 @@ function onClick(item) {
 
 <template>
   <div
-    :class="[
-      'min-w-[180px]',
-      deviceDetection() ? 'max-w-[100%]' : 'max-w-[70%]'
-    ]"
+    :class="['min-w-[180px]', deviceDetection() ? 'max-w-full' : 'max-w-[70%]']"
   >
-    <h3 class="my-8">{{ t("account.accountManagement") }}</h3>
+    <h3 class="my-8!">{{ t("account.accountManagement") }}</h3>
     <div v-for="(item, index) in list" :key="index">
       <div class="flex items-center">
         <div class="flex-1">

--- a/src/views/account/components/Notifications.vue
+++ b/src/views/account/components/Notifications.vue
@@ -21,12 +21,9 @@ const auth = ref({
 
 <template>
   <div
-    :class="[
-      'min-w-[180px]',
-      deviceDetection() ? 'max-w-[100%]' : 'max-w-[70%]'
-    ]"
+    :class="['min-w-[180px]', deviceDetection() ? 'max-w-full' : 'max-w-[70%]']"
   >
-    <h3 class="my-8">{{ t("account.notifications") }}</h3>
+    <h3 class="my-8!">{{ t("account.notifications") }}</h3>
     <MessageNotifications :api="userMsgSubscriptionApi" :auth="auth" />
   </div>
 </template>

--- a/src/views/account/components/Preferences.vue
+++ b/src/views/account/components/Preferences.vue
@@ -53,12 +53,9 @@ onMounted(() => {
 
 <template>
   <div
-    :class="[
-      'min-w-[180px]',
-      deviceDetection() ? 'max-w-[100%]' : 'max-w-[70%]'
-    ]"
+    :class="['min-w-[180px]', deviceDetection() ? 'max-w-full' : 'max-w-[70%]']"
   >
-    <h3 class="my-8">{{ t("account.preference") }}</h3>
+    <h3 class="my-8!">{{ t("account.preference") }}</h3>
     <div v-for="(item, index) in list" :key="index">
       <div class="flex items-center">
         <div class="flex-1">

--- a/src/views/account/components/Profile.vue
+++ b/src/views/account/components/Profile.vue
@@ -26,12 +26,9 @@ const {
 
 <template>
   <div
-    :class="[
-      'min-w-[180px]',
-      deviceDetection() ? 'max-w-[100%]' : 'max-w-[70%]'
-    ]"
+    :class="['min-w-[180px]', deviceDetection() ? 'max-w-full' : 'max-w-[70%]']"
   >
-    <h3 class="my-8">{{ t("account.profile") }}</h3>
+    <h3 class="my-8!">{{ t("account.profile") }}</h3>
     <PlusForm
       ref="formRef"
       v-model="userInfo"
@@ -46,7 +43,7 @@ const {
         <el-avatar :size="80" :src="userinfoStore.avatar ?? avatar" />
         <el-button
           v-if="auth.upload"
-          class="ml-4"
+          class="ml-4!"
           plain
           @click="handleUpload(userInfo)"
         >

--- a/src/views/account/components/SecurityLog.vue
+++ b/src/views/account/components/SecurityLog.vue
@@ -11,12 +11,9 @@ const { t, api, auth, pagination, listColumnsFormat } = useUserLoginLog();
 
 <template>
   <div
-    :class="[
-      'min-w-[180px]',
-      deviceDetection() ? 'max-w-[100%]' : 'max-w-[70%]'
-    ]"
+    :class="['min-w-[180px]', deviceDetection() ? 'max-w-full' : 'max-w-[70%]']"
   >
-    <h3 class="my-8">{{ t("account.securityLog") }}</h3>
+    <h3 class="my-8!">{{ t("account.securityLog") }}</h3>
     <RePlusPage
       ref="tableRef"
       :api="api"


### PR DESCRIPTION
优化个人中心页面元素间隔
----------------------
部分示例如下：
原
<img width="518" height="410" alt="image" src="https://github.com/user-attachments/assets/5c439efc-1ac4-492b-9c1b-65b6c6ebcdb4" />
<img width="628" height="211" alt="image" src="https://github.com/user-attachments/assets/a4e33f68-d6b6-42b1-b630-de6ca3da8364" />
新
<img width="328" height="223" alt="image" src="https://github.com/user-attachments/assets/1ac3205f-a691-4921-a360-99748ae296bf" />
<img width="335" height="208" alt="image" src="https://github.com/user-attachments/assets/09491061-3f82-42a1-9657-1e1de7edf381" />
